### PR TITLE
chore: 移除 domain.json 中的诈骗域名

### DIFF
--- a/domain.json
+++ b/domain.json
@@ -143838,10 +143838,5 @@
     "scam_domain": "pudgy-penguins.live",
     "real_domain": "",
     "comment": "Scam"
-  },
-  {
-    "scam_domain": "aearn.network",
-    "real_domain": "",
-    "comment": "Scam"
   }
 ]


### PR DESCRIPTION
移除了 domain.json 文件中的一个诈骗域名记录：- 删除了 scam_domain 为 "aearn.network" 的条目此次更新有助于维护域名列表的准确性和安全性。